### PR TITLE
Use static file server in tests

### DIFF
--- a/test/test-browsers.js
+++ b/test/test-browsers.js
@@ -43,12 +43,6 @@ import Browser from '../dist';
     });
 
     it('should evaluate JavaScript in the content context', async () => {
-      if (browserName === 'Firefox') {
-        // Firefox doesn't support file URLs, see:
-        // https://bugzilla.mozilla.org/show_bug.cgi?id=1266960
-        return;
-      }
-
       // Get the current tab ID.
       const tabId = (await browser.evaluateInBackground(async () => (
         (await browser.tabs.query({ active: true })).map(tab => tab.id)


### PR DESCRIPTION
This runs a small express app to serve the test pages instead of using local `file://` URLs. This is unfortunately necessary due to [a Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1266960) which prevents Firefox from visiting these URLs.

Closes #22
