### PR TITLE
Remove the postinstall build step

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "express-ws": "^3.0.0",
     "isomorphic-fetch": "^2.2.1",
     "portfinder": "^1.0.13",
-    "postinstall-build": "^5.0.1",
     "selenium-webdriver": "^4.0.0-alpha.1",
     "simple-websocket": "^5.1.0",
     "ws": "^3.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3054,10 +3054,6 @@ portfinder@^1.0.13:
     debug "^2.2.0"
     mkdirp "0.5.x"
 
-postinstall-build@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/postinstall-build/-/postinstall-build-5.0.1.tgz#b917a9079b26178d9a24af5a5cd8cb4a991d11b9"
-
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"


### PR DESCRIPTION
This removes the build step and the dependency. This was useful during
development, but we don't need it now that packages are public.

Closes #50
