### PR TITLE
Include the web client in the package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,11 @@ jobs:
           name: Write version to package.json
           command: $(yarn bin)/dot-json package.json version ${CIRCLE_TAG:1}
       - run:
+          name: Move files from dist into the project root
+          command: |
+            mv dist/* ./
+            rm -rf dist/
+      - run:
           name: Publish to NPM
           command: npm publish --access=public
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,9 @@ jobs:
           key: dependency-cache-{{ checksum "yarn.lock" }}
       - run:
           name: Build
-          command: yarn build
+          command: |
+            yarn build
+            yarn build:web
       - persist_to_workspace:
           root: ~/remote-browser
           paths:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote-browser",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "A low-level browser automation framework built on top of the Web Extensions API standard. ",
   "main": "index.js",
   "repository": "git@github.com:intoli/remote-browser.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote-browser",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "A low-level browser automation framework built on top of the Web Extensions API standard. ",
   "main": "index.js",
   "repository": "git@github.com:intoli/remote-browser.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote-browser",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "A low-level browser automation framework built on top of the Web Extensions API standard. ",
   "main": "index.js",
   "repository": "git@github.com:intoli/remote-browser.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote-browser",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "A low-level browser automation framework built on top of the Web Extensions API standard. ",
   "main": "index.js",
   "repository": "git@github.com:intoli/remote-browser.git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "remote-browser",
   "version": "0.0.6",
   "description": "A low-level browser automation framework built on top of the Web Extensions API standard. ",
-  "main": "dist/index.js",
+  "main": "index.js",
   "repository": "git@github.com:intoli/remote-browser.git",
   "author": "Intoli, LLC <contact@intoli.com>",
   "license": "BSD",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote-browser",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "A low-level browser automation framework built on top of the Web Extensions API standard. ",
   "main": "index.js",
   "repository": "git@github.com:intoli/remote-browser.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote-browser",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "A low-level browser automation framework built on top of the Web Extensions API standard. ",
   "main": "index.js",
   "repository": "git@github.com:intoli/remote-browser.git",

--- a/src/browser.js
+++ b/src/browser.js
@@ -145,7 +145,8 @@ export default class Browser extends CallableProxy {
     if (!remoteBrowserApiUrl) {
       throw new Error((
         'You must specify a remote server using the REMOTE_BROWSER_API_URL environment variable. ' +
-        'This should be specified at build-time when building the web client.'
+        'This should be specified at build-time when building the web client. ' +
+        'It can also be specified as `window.REMOTE_BROWSER_API_URL` using `webpack.DefinePlugin()`.'
       ));
     }
     // We can use `http` or `https` in node, so we won't coerce anything if this is `null`.

--- a/src/browser.js
+++ b/src/browser.js
@@ -140,7 +140,9 @@ export default class Browser extends CallableProxy {
   };
 
   launchRemote = async () => {
-    if (!process.env.REMOTE_BROWSER_API_URL) {
+    // eslint-disable-next-line no-undef
+    const remoteBrowserApiUrl = REMOTE_BROWSER_API_URL || process.env.REMOTE_BROWSER_API_URL;
+    if (!remoteBrowserApiUrl) {
       throw new Error((
         'You must specify a remote server using the REMOTE_BROWSER_API_URL environment variable. ' +
         'This should be specified at build-time when building the web client.'
@@ -150,7 +152,7 @@ export default class Browser extends CallableProxy {
     const secure = typeof window === 'undefined' ? null :
       window.location.protocol.startsWith('https');
 
-    let initializationUrl = process.env.REMOTE_BROWSER_API_URL;
+    let initializationUrl = remoteBrowserApiUrl;
     if (secure && initializationUrl.startsWith('http:')) {
       initializationUrl = `https:${initializationUrl.slice(5)}`;
     } else if (secure === false && initializationUrl.startsWith('https:')) {

--- a/src/browser.js
+++ b/src/browser.js
@@ -140,8 +140,8 @@ export default class Browser extends CallableProxy {
   };
 
   launchRemote = async () => {
-    // eslint-disable-next-line no-undef
-    const remoteBrowserApiUrl = REMOTE_BROWSER_API_URL || process.env.REMOTE_BROWSER_API_URL;
+    const remoteBrowserApiUrl = (window || {}).REMOTE_BROWSER_API_URL
+      || process.env.REMOTE_BROWSER_API_URL;
     if (!remoteBrowserApiUrl) {
       throw new Error((
         'You must specify a remote server using the REMOTE_BROWSER_API_URL environment variable. ' +

--- a/src/browser.js
+++ b/src/browser.js
@@ -140,7 +140,7 @@ export default class Browser extends CallableProxy {
   };
 
   launchRemote = async () => {
-    const remoteBrowserApiUrl = (window || {}).REMOTE_BROWSER_API_URL
+    const remoteBrowserApiUrl = (typeof window === 'undefined' ? null : window.REMOTE_BROWSER_API_URL)
       || process.env.REMOTE_BROWSER_API_URL;
     if (!remoteBrowserApiUrl) {
       throw new Error((

--- a/webpack/web-client.config.js
+++ b/webpack/web-client.config.js
@@ -44,9 +44,6 @@ const options = {
     new webpack.DefinePlugin({
       'typeof window': '"object"',
     }),
-    new webpack.EnvironmentPlugin([
-      'REMOTE_BROWSER_API_URL',
-    ]),
   ],
   target: 'web',
   devtool: 'source-map',


### PR DESCRIPTION
This moves the build products to the package root instead of `dist/` before packaging, and includes `web-client/index.js` as a secondary build targeting browsers.

The package number is also bumped here because I triggered a release to make sure that the new packages were working as expected.


Closes #65
