### PR TITLE
Fix extension resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote-browser",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "A low-level browser automation framework built on top of the Web Extensions API standard. ",
   "main": "index.js",
   "repository": "git@github.com:intoli/remote-browser.git",

--- a/src/launchers.js
+++ b/src/launchers.js
@@ -8,7 +8,7 @@ import { Command } from 'selenium-webdriver/lib/command';
 import firefox from 'selenium-webdriver/firefox';
 
 
-const extension = path && path.resolve && path.resolve(__dirname, '..', 'dist', 'extension');
+const extension = path && path.resolve && path.resolve(__dirname, 'extension');
 
 
 const constructFileUrl = (connectionUrl, sessionId) => (


### PR DESCRIPTION
The resolution of the extension directory was broken after the build outputs were moved out of `dist/` during packaging, so that the web client could be imported as `remote-browser/web-client` (see: [3b125d2d](https://github.com/intoli/remote-browser/commit/3b125d2d4f194235f4ce73a25e581d035d4e5bef). This just removes `dist` from the path when resolving the extension file.

Connects #67
Closes #68
